### PR TITLE
Add Vue + Vite setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,19 @@ An example JSON file is provided as the data source (src/assets/database.json). 
 - Optional: Attractive design - Surprise us with your UI/UX skills 😀
 - Optional: Mobile-friendly design: think about how to make the table responsive
 
+
+## Setup
+
+This project uses [Vue](https://vuejs.org/) with [Vite](https://vitejs.dev/).
+To start the development server run:
+
+```bash
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` by default.
+
+This setup comes preconfigured with **Tailwind CSS v4** and **DaisyUI v5**. Styles are imported in `src/style.css` using the new `@import "tailwindcss"` syntax with DaisyUI.
+
+The default page shows a simple exercise timer component styled with DaisyUI.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 # TODO
 
-- [ ] Write documentation for setting up the project
+- [x] Write documentation for setting up the project

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "testproject",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.8",
+    "tailwindcss": "^4.0.0",
+    "daisyui": "^5.0.0",
+    "postcss": "^8.4.35",
+    "autoprefixer": "^10.4.19"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import ExerciseTimer from './components/ExerciseTimer.vue'
+</script>
+
+<template>
+  <main class="p-4">
+    <ExerciseTimer />
+  </main>
+</template>
+
+<style>
+#app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-weight: normal;
+}
+</style>

--- a/src/components/ExerciseTimer.vue
+++ b/src/components/ExerciseTimer.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+type Mode = 'idle' | 'exercise' | 'setBreak' | 'break' | 'finished'
+
+const totalExercises = ref(5)
+const setsPerExercise = ref(3)
+const exerciseDuration = ref(30)
+const setBreakDuration = ref(5)
+const breakDuration = ref(60)
+
+const timeLeft = ref(exerciseDuration.value)
+const mode = ref<Mode>('idle')
+const currentExercise = ref(1)
+const currentSet = ref(1)
+let interval: ReturnType<typeof setInterval> | null = null
+
+function start() {
+  if (interval) clearInterval(interval)
+  if (mode.value === 'idle' || mode.value === 'finished') {
+    currentExercise.value = 1
+    currentSet.value = 1
+    mode.value = 'exercise'
+    timeLeft.value = exerciseDuration.value
+  }
+  interval = setInterval(tick, 1000)
+}
+
+function pause() {
+  if (interval) {
+    clearInterval(interval)
+    interval = null
+  }
+}
+
+function reset() {
+  pause()
+  mode.value = 'idle'
+  timeLeft.value = exerciseDuration.value
+  currentExercise.value = 1
+  currentSet.value = 1
+}
+
+function tick() {
+  if (timeLeft.value > 0) {
+    timeLeft.value--
+  } else {
+    advance()
+  }
+}
+
+function advance() {
+  if (mode.value === 'exercise') {
+    if (currentSet.value < setsPerExercise.value) {
+      mode.value = 'setBreak'
+      timeLeft.value = setBreakDuration.value
+    } else {
+      mode.value = 'break'
+      timeLeft.value = breakDuration.value
+    }
+  } else if (mode.value === 'setBreak') {
+    currentSet.value++
+    mode.value = 'exercise'
+    timeLeft.value = exerciseDuration.value
+  } else if (mode.value === 'break') {
+    if (currentExercise.value < totalExercises.value) {
+      currentExercise.value++
+      currentSet.value = 1
+      mode.value = 'exercise'
+      timeLeft.value = exerciseDuration.value
+    } else {
+      mode.value = 'finished'
+      pause()
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4 text-center">
+    <div class="text-4xl font-bold">
+      <span v-if="mode !== 'finished'">{{ timeLeft }}</span>
+      <span v-else>Done!</span>
+    </div>
+    <div class="flex justify-center gap-4">
+      <div>Exercise {{ currentExercise }} / {{ totalExercises }}</div>
+      <div>Set {{ currentSet }} / {{ setsPerExercise }}</div>
+    </div>
+    <div class="join">
+      <button class="btn join-item" @click="start">Start</button>
+      <button class="btn join-item" @click="pause">Pause</button>
+      <button class="btn join-item" @click="reset">Reset</button>
+    </div>
+  </div>
+</template>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ msg: string }>()
+</script>
+
+<template>
+  <h1>{{ msg }}</h1>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './style.css'
+
+createApp(App).mount('#app')

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+@config '../tailwind.config.js';
+@import 'tailwindcss';
+@import 'daisyui';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,5 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  plugins: [require('daisyui')],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()]
+})


### PR DESCRIPTION
## Summary
- integrate a simple Vue app bootstrapped with Vite
- document how to run the project and check off the TODO item
- configure Tailwind CSS v4 with DaisyUI v5
- add an exercise timer component that showcases DaisyUI styling

## Testing
- `npm run build` *(fails: vite not found)*